### PR TITLE
Initialize scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM onmodulus/run-base
+
+ADD . /opt/modulus
+ENV PATH=/opt/modulus/bin:$PATH
+
+RUN /opt/modulus/bootstrap.sh
+
+WORKDIR /mnt/app
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]

--- a/bin/start
+++ b/bin/start
@@ -10,5 +10,5 @@ fi
 
 cd $APP_DIR
 source $HOME/.dnx/dnvm/dnvm.sh
-dnx web --server.urls=http://*:8080/ &
+dnx web --server.urls=http://*:$PORT/ &
 wait

--- a/bin/start
+++ b/bin/start
@@ -3,7 +3,9 @@ set -e
 
 # import $HOME
 if [ ! -d $HOME/.dnx ]; then
-  mv $APP_DIR/.modulus/home/ /mnt
+  GLOBIGNORE='n*'
+  mv $APP_DIR/.modulus/home/* /mnt/home
+  unset GLOBIGNORE
 fi
 
 cd $HOME

--- a/bin/start
+++ b/bin/start
@@ -8,9 +8,6 @@ if [ ! -d $HOME/.dnx ]; then
   unset GLOBIGNORE
 fi
 
-cd $HOME
-ldconfig
-
 cd $APP_DIR
 source $HOME/.dnx/dnvm/dnvm.sh
 dnx web --server.urls=http://*:8080/ &

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+# import $HOME
+if [ ! -d $HOME/.dnx ]; then
+  mv $APP_DIR/.modulus/home/ /mnt
+fi
+
+cd $HOME
+ldconfig
+
+cd $APP_DIR
+source $HOME/.dnx/dnvm/dnvm.sh
+dnx web --server.urls=http://*:8080/ &
+wait

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,3 +24,4 @@ cd ~/ && ldconfig
 
 # clean up
 apt-get autoclean && apt-get autoremove -y && apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+export TMPDIR=/tmp
+export HOME=/root
+
+apt-get update
+
+# install dnx prerequisite
+apt-get install -y libunwind8 gettext libssl-dev libcurl4-openssl-dev zlib1g \
+  libicu-dev uuid-dev
+
+# install Libuv
+apt-get -y install make automake libtool
+curl -sSL https://github.com/libuv/libuv/archive/v1.8.0.tar.gz \
+  | tar zxfv - -C /usr/local/src
+cd /usr/local/src/libuv-1.8.0
+sh autogen.sh
+./configure
+make
+make install
+rm -rf /usr/local/src/libuv-1.8.0
+
+# clean up
+apt-get autoclean && apt-get autoremove -y && apt-get clean

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,6 +20,7 @@ sh autogen.sh
 make
 make install
 rm -rf /usr/local/src/libuv-1.8.0
+cd ~/ && ldconfig
 
 # clean up
 apt-get autoclean && apt-get autoremove -y && apt-get clean


### PR DESCRIPTION
Use run-base and bootstrap to install dependencies. Start script copies
$HOME from bundle and source dnx dependencies from it. Starts a server
on 8080.
